### PR TITLE
Added support to filter country list. 

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -138,6 +138,9 @@ class _MyHomePageState extends State<MyHomePage> {
                       cityValue = value;
                     });
                   },
+
+                  ///Show only specific countries using country filter
+                  // countryFilter: ["United States", "Canada", "Mexico"],
                 ),
 
                 ///print newly selected country state and city in Text Widget

--- a/lib/csc_picker.dart
+++ b/lib/csc_picker.dart
@@ -7,7 +7,9 @@ import 'package:flutter/material.dart';
 import 'model/select_status_model.dart';
 
 enum Layout { vertical, horizontal }
+
 enum CountryFlag { SHOW_IN_DROP_DOWN_ONLY, ENABLE, DISABLE }
+
 enum DefaultCountry {
   Afghanistan,
   Aland_Islands,
@@ -260,6 +262,7 @@ enum DefaultCountry {
   Curacao,
   Sint_Maarten_Dutch_part
 }
+
 const Map<DefaultCountry, int> DefaultCountries = {
   DefaultCountry.Afghanistan: 0,
   DefaultCountry.Aland_Islands: 1,
@@ -542,6 +545,7 @@ class CSCPicker extends StatefulWidget {
     this.countryDropdownLabel = "Country",
     this.stateDropdownLabel = "State",
     this.cityDropdownLabel = "City",
+    this.countryFilter,
   }) : super(key: key);
 
   final ValueChanged<String>? onCountryChanged;
@@ -573,6 +577,8 @@ class CSCPicker extends StatefulWidget {
   final String stateDropdownLabel;
   final String cityDropdownLabel;
 
+  final List<String>? countryFilter;
+
   @override
   CSCPickerState createState() => CSCPickerState();
 }
@@ -581,6 +587,7 @@ class CSCPickerState extends State<CSCPicker> {
   List<String?> _cities = [];
   List<String?> _country = [];
   List<String?> _states = [];
+  List<String> _countryFilter = [];
 
   String _selectedCity = 'City';
   String? _selectedCountry;
@@ -591,6 +598,9 @@ class CSCPickerState extends State<CSCPicker> {
   void initState() {
     super.initState();
     setDefaults();
+    if (widget.countryFilter != null) {
+      _countryFilter = widget.countryFilter!;
+    }
     getCountries();
     _selectedCity = widget.cityDropdownLabel;
     _selectedState = widget.stateDropdownLabel;
@@ -630,22 +640,36 @@ class CSCPickerState extends State<CSCPicker> {
   Future<List<String?>> getCountries() async {
     _country.clear();
     var countries = await getResponse() as List;
-    countries.forEach((data) {
-      var model = Country();
-      model.name = data['name'];
-      model.emoji = data['emoji'];
-      if (!mounted) return;
-      setState(() {
-        widget.flagState == CountryFlag.ENABLE ||
-                widget.flagState == CountryFlag.SHOW_IN_DROP_DOWN_ONLY
-            ? _country.add(model.emoji! +
-                "    " +
-                model.name!) /* : _country.add(model.name)*/
-            : _country.add(model.name);
+    if (_countryFilter.isNotEmpty) {
+      countries.forEach((data) {
+        String name = data['name'];
+        if (_countryFilter.contains(name)) {
+          addCountryToList(data);
+        }
       });
-    });
+    } else {
+      countries.forEach((data) {
+        addCountryToList(data);
+      });
+    }
     _setDefaultCountry();
     return _country;
+  }
+
+  ///Add a country to country list
+  void addCountryToList(data) {
+    var model = Country();
+    model.name = data['name'];
+    model.emoji = data['emoji'];
+    if (!mounted) return;
+    setState(() {
+      widget.flagState == CountryFlag.ENABLE ||
+              widget.flagState == CountryFlag.SHOW_IN_DROP_DOWN_ONLY
+          ? _country.add(model.emoji! +
+              "    " +
+              model.name!) /* : _country.add(model.name)*/
+          : _country.add(model.name);
+    });
   }
 
   ///get states from json response


### PR DESCRIPTION
User must have option to limit the country list. For example, if user want to show certain ser of countries like United State, Canada, Mexico, etc, there must be an option to show only the countries, not all.

I have added countryFilter to show only certain set of countries & rest of the countries won't be displayed.

Here I have added  **countryFilter** property for **CSCPicker** widget & through this property user can pass a list of countries which need to be shown. If **countryFilter** property is specified or it is empty, all the countries will be displayed in the drop down.