### PR TITLE
vertical layout hiding cities and states properly

### DIFF
--- a/lib/csc_picker.dart
+++ b/lib/csc_picker.dart
@@ -806,11 +806,15 @@ class CSCPickerState extends State<CSCPicker> {
                   SizedBox(
                     height: 10.0,
                   ),
-                  stateDropdown(),
+                  widget.showStates
+                      ? stateDropdown()
+                      : Container(),
                   SizedBox(
                     height: 10.0,
                   ),
-                  cityDropdown()
+                  widget.showStates && widget.showCities
+                      ? cityDropdown()
+                      : Container()
                 ],
               )
             : Column(


### PR DESCRIPTION
Fixed issue where
when layout is vertical, showStates and showCities values are ignored
