### PR TITLE
Issue #92 - A value of type 'DialogThemeData' can't be assigned to a variable of type 'DialogTheme'

### DIFF
--- a/lib/dropdown_with_search.dart
+++ b/lib/dropdown_with_search.dart
@@ -317,7 +317,7 @@ class CustomDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final DialogTheme dialogTheme = DialogTheme.of(context);
+    final DialogThemeData dialogThemeData = DialogTheme.of(context);
     return AnimatedPadding(
       padding: MediaQuery.of(context).viewInsets +
           const EdgeInsets.symmetric(horizontal: 22.0, vertical: 24.0),


### PR DESCRIPTION
I have solved variable type issue , it occurs due to flutter update 3.27.0.