### PR TITLE
Compatibility with flutter’s new version

### DIFF
--- a/lib/csc_picker.dart
+++ b/lib/csc_picker.dart
@@ -1,9 +1,11 @@
 library csc_picker;
 
-import 'package:csc_picker/dropdown_with_search.dart';
-import 'package:flutter/services.dart' show rootBundle;
 import 'dart:convert';
+
+import 'package:csc_picker/dropdown_with_search.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+
 import 'model/select_status_model.dart';
 
 enum Layout { vertical, horizontal }
@@ -545,9 +547,8 @@ class CSCPicker extends StatefulWidget {
     this.countryDropdownLabel = "Country",
     this.stateDropdownLabel = "State",
     this.cityDropdownLabel = "City",
-
-    this.countryFilter, this.selectedItemPadding,
     this.countryFilter,
+    this.selectedItemPadding,
   }) : super(key: key);
 
   final ValueChanged<String>? onCountryChanged;
@@ -647,7 +648,7 @@ class CSCPickerState extends State<CSCPicker> {
     if (_countryFilter.isNotEmpty) {
       _countryFilter.forEach((element) {
         var result = countries[Countries[element]!];
-        if(result!=null) addCountryToList(result);
+        if (result != null) addCountryToList(result);
       });
     } else {
       countries.forEach((data) {
@@ -807,13 +808,11 @@ class CSCPickerState extends State<CSCPicker> {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: <Widget>[
                   countryDropdown(),
-                  SizedBox(
+                  const SizedBox(
                     height: 10.0,
                   ),
-                  widget.showStates
-                      ? stateDropdown()
-                      : Container(),
-                  SizedBox(
+                  widget.showStates ? stateDropdown() : Container(),
+                  const SizedBox(
                     height: 10.0,
                   ),
                   widget.showStates && widget.showCities
@@ -828,7 +827,7 @@ class CSCPickerState extends State<CSCPicker> {
                     children: <Widget>[
                       Expanded(child: countryDropdown()),
                       widget.showStates
-                          ? SizedBox(
+                          ? const SizedBox(
                               width: 10.0,
                             )
                           : Container(),
@@ -837,7 +836,7 @@ class CSCPickerState extends State<CSCPicker> {
                           : Container(),
                     ],
                   ),
-                  SizedBox(
+                  const SizedBox(
                     height: 10.0,
                   ),
                   widget.showStates && widget.showCities

--- a/lib/dropdown_with_search.dart
+++ b/lib/dropdown_with_search.dart
@@ -66,18 +66,19 @@ class DropdownWithSearch<T> extends StatelessWidget {
           });
         },
         child: Container(
-          padding: selectedItemPadding ?? EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+          padding: selectedItemPadding ??
+              const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
           decoration: !disabled
               ? decoration != null
                   ? decoration
                   : BoxDecoration(
-                      borderRadius: BorderRadius.all(Radius.circular(5)),
+                      borderRadius: const BorderRadius.all(Radius.circular(5)),
                       color: Colors.white,
                       border: Border.all(color: Colors.grey.shade300, width: 1))
               : disabledDecoration != null
                   ? disabledDecoration
                   : BoxDecoration(
-                      borderRadius: BorderRadius.all(Radius.circular(5)),
+                      borderRadius: const BorderRadius.all(Radius.circular(5)),
                       color: Colors.grey.shade300,
                       border:
                           Border.all(color: Colors.grey.shade300, width: 1)),
@@ -88,8 +89,8 @@ class DropdownWithSearch<T> extends StatelessWidget {
                       overflow: TextOverflow.ellipsis,
                       style: selectedItemStyle != null
                           ? selectedItemStyle
-                          : TextStyle(fontSize: 14))),
-              Icon(Icons.keyboard_arrow_down_rounded)
+                          : const TextStyle(fontSize: 14))),
+              const Icon(Icons.keyboard_arrow_down_rounded)
             ],
           ),
         ),
@@ -169,16 +170,17 @@ class _SearchDialogState<T> extends State<SearchDialog> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 Container(
-                  margin: EdgeInsets.symmetric(horizontal: 16),
+                  margin: const EdgeInsets.symmetric(horizontal: 16),
                   child: Text(
                     widget.title,
                     style: widget.titleStyle != null
                         ? widget.titleStyle
-                        : TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                        : const TextStyle(
+                            fontSize: 16, fontWeight: FontWeight.w500),
                   ),
                 ),
                 IconButton(
-                    icon: Icon(Icons.close),
+                    icon: const Icon(Icons.close),
                     onPressed: () {
                       FocusScope.of(context).unfocus();
                       Navigator.pop(context);
@@ -199,20 +201,20 @@ class _SearchDialogState<T> extends State<SearchDialog> {
               )*/
               ],
             ),
-            SizedBox(height: 5),
+            const SizedBox(height: 5),
             Container(
-              margin: EdgeInsets.symmetric(horizontal: 16),
+              margin: const EdgeInsets.symmetric(horizontal: 16),
               child: TextField(
                 autofocus: true,
                 decoration: InputDecoration(
                   isDense: true,
-                  prefixIcon: Icon(Icons.search),
+                  prefixIcon: const Icon(Icons.search),
                   hintText: widget.placeHolder,
                   focusedBorder: OutlineInputBorder(
                     borderRadius: BorderRadius.all(
                         widget.searchInputRadius != null
                             ? Radius.circular(widget.searchInputRadius!)
-                            : Radius.circular(5)),
+                            : const Radius.circular(5)),
                     borderSide: const BorderSide(
                       color: Colors.black26,
                     ),
@@ -221,22 +223,22 @@ class _SearchDialogState<T> extends State<SearchDialog> {
                     borderRadius: BorderRadius.all(
                         widget.searchInputRadius != null
                             ? Radius.circular(widget.searchInputRadius!)
-                            : Radius.circular(5)),
+                            : const Radius.circular(5)),
                     borderSide: const BorderSide(color: Colors.black12),
                   ),
                 ),
                 style: widget.itemStyle != null
                     ? widget.itemStyle
-                    : TextStyle(fontSize: 14),
+                    : const TextStyle(fontSize: 14),
                 controller: textController,
               ),
             ),
-            SizedBox(height: 5),
+            const SizedBox(height: 5),
             Expanded(
               child: ClipRRect(
                 borderRadius: BorderRadius.all(widget.dialogRadius != null
                     ? Radius.circular(widget.dialogRadius!)
-                    : Radius.circular(5)),
+                    : const Radius.circular(5)),
                 //borderRadius: widget.dialogRadius!=null?BorderRadius.circular(widget.dropDownRadius!):BorderRadius.circular(14),
                 child: ListView.builder(
                     itemCount: filteredList.length,
@@ -253,7 +255,7 @@ class _SearchDialogState<T> extends State<SearchDialog> {
                               filteredList[index].toString(),
                               style: widget.itemStyle != null
                                   ? widget.itemStyle
-                                  : TextStyle(fontSize: 14),
+                                  : const TextStyle(fontSize: 14),
                             ),
                           ));
                     }),
@@ -318,7 +320,7 @@ class CustomDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final DialogTheme dialogTheme = DialogTheme.of(context);
+    final DialogThemeData dialogTheme = DialogTheme.of(context);
     return AnimatedPadding(
       padding: MediaQuery.of(context).viewInsets +
           const EdgeInsets.symmetric(horizontal: 22.0, vertical: 24.0),


### PR DESCRIPTION
In Flutter 3.29.3 I got an error of:
```
Error (Xcode): ../../../../../../.pub-cache/hosted/pub.dev/csc_picker-0.2.7/lib/dropdown_with_search.dart:320:49: Error: A value of type 'DialogThemeData' can't be assigned to a variable of type 'DialogTheme'.
```
Sorry for all the collateral changes in formatting/const.